### PR TITLE
Proper support for hashtable resource properties

### DIFF
--- a/Tooling/cDscResourceDesigner/cDscResourceDesigner.psm1
+++ b/Tooling/cDscResourceDesigner/cDscResourceDesigner.psm1
@@ -1,4 +1,4 @@
- #Requires -RunAsAdministrator
+﻿ #Requires -RunAsAdministrator
 # A global variable that contains localized messages.
 data LocalizedData
 {
@@ -204,7 +204,7 @@ $TypeMap = @{
         "Boolean" = [System.Boolean];
         "DateTime"= [System.DateTime];
         
-        "Hashtable"    = [System.Collections.Hashtable];
+        "Hashtable"    = [Microsoft.Management.Infrastructure.CimInstance[]];
         "PSCredential" = [PSCredential];
 
         "Uint8[]"   = [System.Byte[]];
@@ -222,7 +222,7 @@ $TypeMap = @{
         "Boolean[]" = [System.Boolean[]];
         "DateTime[]"= [System.DateTime[]];
         
-        "Hashtable[]"    = [System.Collections.Hashtable[]];
+        "Hashtable[]"    = [Microsoft.Management.Infrastructure.CimInstance[]];
         "PSCredential[]" = [PSCredential[]];
     }
 
@@ -773,6 +773,9 @@ function Test-TypeIsArray
         $Type
     )
     # Returns true if $Type ends with "[]"
+	if($Type -like "hashtable") {
+		return $true;
+	}
     return ($Type -cmatch "^[a-zA-Z][\w_]*\[\]$")
 }
 


### PR DESCRIPTION
Previously, the type mapping was not allowing the returned type to be converted back to powershell.  I need to create a Toekn replacement DSC resource and one of the properties is a hashtable.  Currently, the DSC disgner does not correctly generate the type in the .schema.mif file and the type in the Resource .PSM1 file.  This patch will generate all hashtable types as "Microsoft.Management.Infrastructure.CimInstance[]" in the .PSM1 module file and as string arrays of type EmbeddedInstance("MSFT_KeyValuePair")  
