### PR TITLE
Fix default New-cDscCompositeResource Behavior

### DIFF
--- a/Tooling/DscDevelopment/New-DscCompositeResource.ps1
+++ b/Tooling/DscDevelopment/New-DscCompositeResource.ps1
@@ -73,6 +73,7 @@ Function New-cDscCompositeResource
             
             if ((-not (test-path $resourcePSM)) -or ($force)) { 
                 New-Item -ItemType File -Path $resourcePSM -Force:$Force | Out-Null
+                Add-Content -Path $resourcePSM -Value "Configuration $ResourceName`n{`n}"
             }
             if ((-not (test-path $resourcePSD)) -or ($force)) { 
                 New-ModuleManifest -Path $resourcePSD -RootModule $resourcePSMName -ModuleVersion '1.0.0' -Author $Author -CompanyName $Company -Copyright $Copyright


### PR DESCRIPTION
Have New-cDscComposite resource set an empty configuration block if a new CompositeResource is created, since Get-DscResource will not discover or import if the file is empty.

Enable New-cDscCompositeResource to set author, company, and copyright values on the root module and the resource modules
