### PR TITLE
Adding output types to Website.psm1

### DIFF
--- a/Resources/cWebAdministration/DSCResources/PSHOrg_cWebsite/PSHOrg_cWebsite.psm1
+++ b/Resources/cWebAdministration/DSCResources/PSHOrg_cWebsite/PSHOrg_cWebsite.psm1
@@ -21,6 +21,7 @@ WebsiteStateFailureError=Failure to successfully set the state of the website {0
 # It gives the Website info of the requested role/feature on the target machine.  
 function Get-TargetResource 
 {
+    [OutputType([System.Collections.Hashtable])]
     param 
     (   
         [Parameter(Mandatory)]
@@ -277,6 +278,7 @@ function Set-TargetResource
 # The Test-TargetResource cmdlet is used to validate if the role or feature is in a state as expected in the instance document.
 function Test-TargetResource 
 {
+    [OutputType([System.Boolean])]
     param 
     (       
         [ValidateSet("Present", "Absent")]


### PR DESCRIPTION
This was causing warnings when running invoke-dscbuild as it didn't have the correct output type.
