### PR TITLE
Fixed wrong variable name in New-DscSiteMetadata

### DIFF
--- a/Tooling/DscConfiguration/New-DscNodeMetadata.ps1
+++ b/Tooling/DscConfiguration/New-DscNodeMetadata.ps1
@@ -127,7 +127,7 @@ function New-DscSiteMetadata {
         $SiteDataConfigurationPath = (join-path $script:ConfigurationDataPath 'SiteData')         
     }
     process {
-        Out-ConfigurationDataFile -Parameters $psboundparameters -ConfigurationDataPath $ServicesConfigurationPath
+        Out-ConfigurationDataFile -Parameters $psboundparameters -ConfigurationDataPath $SiteDataConfigurationPath
     }
 }
 


### PR DESCRIPTION
`Begin` block was initializing `$SiteDataConfigurationPath`, but the `process` block was referencing `$ServicesConfigurationPath` instead, causing errors in `Out-ConfigurationDataFile`.
