### PR TITLE
Fixed possible infinite loop in Resolve-DscConfigurationProperty

### DIFF
--- a/Tooling/dscbuild/Resolve-ConfigurationProperty.ps1
+++ b/Tooling/dscbuild/Resolve-ConfigurationProperty.ps1
@@ -56,9 +56,9 @@ function Resolve-DscConfigurationProperty {
 				Write-Verbose "`t`tNothing in scope $ScopeToCheck for ConfigurationData"
 			}
 			$ScopeToCheck++
-		} while (($ConfigurationData.Keys.Count -eq 0) -or ($ScopeToCheck -eq 6))
+		} until ($ScopeToCheck -gt 5 -or ($ConfigurationData -is [hashtable] -and $ConfigurationData.Keys.Count -gt 0))
 
-		if ($ConfigurationData.Keys.Count -eq 0) {
+		if ($ConfigurationData -isnot [hashtable] -or $ConfigurationData.Keys.Count -eq 0) {
 			throw 'Failed to resolve ConfigurationData.  Please confirm that $ConfigurationData is property set in a scope above this Resolve-DscConfigurationProperty or passed to Resolve-DscConfigurationProperty via the ConfigurationData parameter.'
 		}
 		else {


### PR DESCRIPTION
Loop condition appeared to be intended to only check 5 or 6 scopes before bailing, but the logic was flawed, and the loop would go on forever unless it found a valid $ConfigurationData variable.
