### PR TITLE
Function path referring to xPSDesiredStateConfiguration naming conventio...

### DIFF
--- a/Resources/cPSDesiredStateConfiguration/DSCResources/PSHOrg_cDSCWebService/PSHOrg_cDSCWebService.psm1
+++ b/Resources/cPSDesiredStateConfiguration/DSCResources/PSHOrg_cDSCWebService/PSHOrg_cDSCWebService.psm1
@@ -133,7 +133,7 @@ function Set-TargetResource
     }
                 
     Write-Verbose "Create the IIS endpoint"    
-    xPSDesiredStateConfiguration\New-PSWSEndpoint -site $EndpointName `
+    cPSDesiredStateConfiguration\New-PSWSEndpoint -site $EndpointName `
                      -path $PhysicalPath `
                      -cfgfile $webConfigFileName `
                      -port $Port `


### PR DESCRIPTION
Resource was generating error. Path to function was referring to Microsoft "x" prefix instead of "c" prefix.
