### PR TITLE
Get-ConfigurationData does not filter data

### DIFF
--- a/Tooling/DscConfiguration/Get-ConfigurationData.ps1
+++ b/Tooling/DscConfiguration/Get-ConfigurationData.ps1
@@ -4,27 +4,20 @@ function Get-DscConfigurationData
     param (
         [parameter()]
         [ValidateNotNullOrEmpty()]
-        [string]
-        $Path,
-        [parameter(
-            ParameterSetName = 'NameFilter'
-        )]
-        [string]
-        $Name,
-        [parameter(
-            ParameterSetName = 'NodeNameFilter'  
-        )]
-        [string]
-        $NodeName,
-        [parameter(
-            ParameterSetName = 'RoleFilter'  
-        )]
-        [string]
-        $Role, 
+        [string] $Path,
+
+        [parameter(ParameterSetName = 'NameFilter')]
+        [string] $Name,
+
+        [parameter(ParameterSetName = 'NodeNameFilter')]
+        [string] $NodeName,
+
+        [parameter(ParameterSetName = 'RoleFilter')]
+        [string] $Role,
+
         [parameter()]
-        [switch]
-        $Force
-    )             
+        [switch] $Force
+    )
 
     begin {
 
@@ -37,47 +30,42 @@ function Get-DscConfigurationData
             $ResolveConfigurationDataPathParams.Path = $path
         }
         Resolve-ConfigurationDataPath @ResolveConfigurationDataPathParams
-        
+
     }
-    end { 
+    end {
 
         Get-AllNodesConfigurationData
 
-        $ofs = ', '
-        $FilteredResults = $true
         Write-Verbose 'Checking for filters of AllNodes.'
         switch ($PSCmdlet.ParameterSetName)
         {
-            'Name'  {            
+            'NameFilter' {
                 Write-Verbose "Filtering for nodes with the Name $Name"
                 $script:ConfigurationData.AllNodes = $script:ConfigurationData.AllNodes.Where({$_.Name -like $Name})
             }
-            'NodeName' {            
+            'NodeNameFilter' {
                 Write-Verbose "Filtering for nodes with the GUID of $NodeName"
                 $script:ConfigurationData.AllNodes = $script:ConfigurationData.AllNodes.Where({$_.NodeName -like $NodeName})
             }
-            'Role'  {
+            'RoleFilter' {
                 Write-Verbose "Filtering for nodes with the Role of $Role"
                 $script:ConfigurationData.AllNodes = $script:ConfigurationData.AllNodes.Where({ $_.roles -contains $Role})
             }
             default {
                 Write-Verbose 'Loading Site Data'
-                Get-SiteDataConfigurationData 
+                Get-SiteDataConfigurationData
                 Write-Verbose 'Loading Services Data'
-                Get-ServiceConfigurationData 
+                Get-ServiceConfigurationData
                 Write-Verbose 'Loading Credential Data'
-                Get-CredentialConfigurationData 
+                Get-CredentialConfigurationData
                 Write-Verbose 'Loading Application Data'
-                Get-ApplicationConfigurationData 
+                Get-ApplicationConfigurationData
             }
         }
 
         Add-NodeRoleFromServiceConfigurationData
         return $script:ConfigurationData
     }
-
-    
 }
 
 Set-Alias -Name 'Get-ConfigurationData' -Value 'Get-DscConfigurationData'
-


### PR DESCRIPTION
I ran into a problem where the filtering wasn't working as expected.  Taking a look at this I discovered that the switch statement was only ever hitting default.

The basic change was to add "filter" to the switch statement to match the parameter set name. I also cleaned up the style a bit 'cause of my personal OCD, though I can completely roll that back if needed.
