### PR TITLE
Added Invoke-DscApply

### DIFF
--- a/Tooling/DscOperations/DscOperations.psd1
+++ b/Tooling/DscOperations/DscOperations.psd1
@@ -12,7 +12,7 @@
 RootModule = 'DscOperations.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.5.4.0'
+ModuleVersion = '1.5.5.0'
 
 # ID used to uniquely identify this module
 GUID = 'c5e2c892-c16d-4649-9d65-dc14c0bddcb9'
@@ -66,7 +66,7 @@ RequiredModules = @('DscConfiguration', 'DscBuild')
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = 'Clear-DscEventLog', 'Clear-DscTemporaryModule', 'Invoke-DscPull', 'Set-DscClient'
+FunctionsToExport = 'Clear-DscEventLog', 'Clear-DscTemporaryModule', 'Invoke-DscPull', 'Set-DscClient', 'Invoke-DscApply'
 
 # Cmdlets to export from this module
 #CmdletsToExport = '*'

--- a/Tooling/DscOperations/DscOperations.psm1
+++ b/Tooling/DscOperations/DscOperations.psm1
@@ -2,4 +2,4 @@
 . $psscriptroot\Invoke-DscPull.ps1
 . $psscriptroot\Clear-DscEventLog.ps1
 . $psscriptroot\Clear-DscTemporaryModule.ps1
-
+. $psscriptroot\Invoke-DscApply.ps1

--- a/Tooling/DscOperations/Invoke-DscApply.ps1
+++ b/Tooling/DscOperations/Invoke-DscApply.ps1
@@ -1,0 +1,35 @@
+function Invoke-DscApply
+{
+    <#
+        .Synopsis
+            Uses the Configuration Agent to apply the configuration that is pending.
+        .Description
+            Uses the Configuration Agent to apply the configuration that is pending.  
+            If there is no configuration pending, this method reapplies the current configuration.
+        .Example
+            Invoke-DscApply -CimSession SERVER01 -Verbose
+        .Example
+            1..7 | Invoke-DscApply -CimSession {"SERVER0$_"} 
+            
+    #>
+    param (
+        [parameter(ValueFromPipeline=$true, Position=0)]
+        [alias('ComputerName', 'Name', '__Server')]
+        $CimSession = $null
+        )
+    
+    Process {
+
+        $parameters = @{        
+        Namespace = 'root/microsoft/windows/desiredstateconfiguration'
+        Class  = 'MSFT_DscLocalConfigurationManager'
+        MethodName = 'ApplyConfiguration'
+        }
+    
+        Write-Verbose ""
+        Write-Verbose "Forcing an application of configuration on $CimSession"
+        Invoke-CimMethod @parameters @PSBoundParameters
+    }
+}
+
+


### PR DESCRIPTION
Added Invoke-DscApply function to DscOperations module.
Calls the ApplyConfiguration method of MSFT_DSCLocalConfigurationManager, similar to Invoke-DscPull calling PerformRequiredConfigurationChecks.
This method will immediately reapply the current configuration, eliminating the need to "poke" multiple times with Invoke-DscPull to trigger the application of configuration. Useful for demonstrating DSC autocorrecting configuration drift.

http://msdn.microsoft.com/en-us/library/dn469245(v=vs.85).aspx
