### PR TITLE
IdentityType Optional

### DIFF
--- a/Resources/cWebAdministration/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
+++ b/Resources/cWebAdministration/DSCResources/PSHOrg_cAppPool/PSHOrg_cAppPool.psm1
@@ -416,7 +416,7 @@ function Test-TargetResource
             #Only check username and password if IdentityType is set to specific user 
             if ($identityType -eq "SpecificUser"){
 
-                if ($PoolConfig.add.processModel.userName -ne $userName){
+                if ($PSBoundParameters.ContainsKey("UserName")){
                     if($PoolConfig.add.processModel.userName -ne $userName){
                         $DesiredConfigurationMatch = $false
                         Write-Verbose "userName of AppPool $Name does not match the desired state."


### PR DESCRIPTION
I removed the default value for Identity Type and updated the Set/Test to only update username and password if the IdentityType is "SpecificUser".

I also Added Enable32Bit as a parameter that defaults to false.
