### PR TITLE
Updated cRDPEnabled

### DIFF
--- a/Resources/cRDPEnabled/DSCResources/PSHOrg_cRDPEnabled/PSHOrg_cRDPEnabled.psm1
+++ b/Resources/cRDPEnabled/DSCResources/PSHOrg_cRDPEnabled/PSHOrg_cRDPEnabled.psm1
@@ -6,12 +6,40 @@ function Get-TargetResource
 	(
 		[parameter(Mandatory = $true)]
 		[System.Boolean]
-		$Enabled
+		$Enabled,
+
+		[System.Boolean]
+        $NLARequired = $true,
+
+		[System.Boolean]
+        $EnableDefaultFirewallRule = $true
 	)
 
-	Write-Verbose "Checking Win32_TerminalServiceSetting."
-	[boolean]$val = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TerminalServiceSetting).AllowTSConnections
-    @{Enabled = $val}
+	Write-Verbose "Starting Get operation"
+	[Boolean]$CurrentRDPEnabled                 = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop).AllowTSConnections
+    [Boolean]$CurrentNLARequired                = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TSGeneralSetting -ErrorAction Stop).UserAuthenticationRequired
+    [Boolean]$CurrentEnableDefaultFirewallRule  = $true
+    $FirewallRules                              = Get-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)","Remote Desktop - User Mode (UDP-In)" -ErrorAction Stop
+
+    if ($CurrentRDPEnabled) {
+        foreach ($rule in $FirewallRules) {
+            if ($rule.Enabled -ne "True") {
+                $CurrentEnableDefaultFirewallRule = $false
+                break
+            }
+        }
+    }
+    else { # We don't care about the result if RDP is not enabled
+        $CurrentEnableDefaultFirewallRule = $false
+    }
+
+    @{
+        Enabled                    = $CurrentRDPEnabled;
+        NLARequired                = $CurrentNLARequired;
+        EnableDefaultFirewallRule  = $CurrentEnableDefaultFirewallRule
+     }
+
+     Write-Verbose "Completed Get operation"
 }
 
 
@@ -22,26 +50,63 @@ function Set-TargetResource
 	(
 		[parameter(Mandatory = $true)]
 		[System.Boolean]
-		$Enabled
+		$Enabled,
+
+		[System.Boolean]
+        $NLARequired = $true,
+
+		[System.Boolean]
+        $EnableDefaultFirewallRule = $true
 	)
 
-	Write-Verbose "Starting set operation."
-	Write-Debug "Calling invoke-cimmethod on win32_TerminalServiceSetting."
+	Write-Verbose "Starting Set operation"
+	Write-Debug "Calling Invoke-CimMethod on win32_TerminalServiceSetting"
     Switch ($Enabled)
       {
         $true {
             Write-Verbose 'Beginning operation to set RDP to enabled'
-            Get-CimInstance -Namespace root\cimv2\TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop |
-            Invoke-CimMethod -MethodName SetAllowTSConnections -Arguments @{AllowTSConnections=1}
-            Write-Debug 'Completed Set RDP to enabled.'
+
+            try {
+                Get-CimInstance -Namespace root\cimv2\TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop |
+                Invoke-CimMethod -MethodName SetAllowTSConnections -Arguments @{AllowTSConnections=1} -ErrorAction Stop
+            }
+            catch {
+                Write-Error "Error during Invoke-CimMethod. This might happen if you have a GPO that forces the RDP configuration on the server.`n$_"
+            }
+            
+            Write-Verbose 'Completed Set RDP to enabled.'
+
+            if ($EnableDefaultFirewallRule) {
+                Write-Verbose "Beginning operation to enable default Remote Desktop firewall rules"
+                Get-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)","Remote Desktop - User Mode (UDP-In)" -ErrorAction Stop | Enable-NetFirewallRule -ErrorAction Stop
+                Write-Verbose 'Completed operation to enable default Remote Desktop firewall rules'
+            }
           }
         $false {
             Write-Verbose 'Beginning operation to set RDP to disabled'
-            Get-CimInstance -Namespace root\cimv2\TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop |
-            Invoke-CimMethod -MethodName SetAllowTSConnections -Arguments @{AllowTSConnections=0}
-            Write-Debug 'Completed Set RDP to disabled.'
+
+            try {
+                Get-CimInstance -Namespace root\cimv2\TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop |
+                Invoke-CimMethod -MethodName SetAllowTSConnections -Arguments @{AllowTSConnections=0;ModifyFirewallException=1} -ErrorAction Stop # ModifyFirewallException will close the 'Remote Desktop' group firewall rule, if it's enabled
+            }
+            catch {
+                Write-Error "Error during Invoke-CimMethod. This might happen if you have a GPO that forces the RDP configuration on the server.`n$_"
+            }
+
+            Write-Verbose 'Completed Set RDP to disabled.'
           }
       }
+      Write-Debug "Completed Invoke-CimMethod on win32_TerminalServiceSetting"
+
+      Write-Debug "Calling Invoke-CimMethod on win32_TSGeneralSetting"
+      
+      Write-Verbose "Beginning operation to set NLA required to $NLARequired"
+      Get-CimInstance -Class "win32_TSGeneralSetting" -Namespace root\cimv2\terminalservices -Filter "TerminalName='RDP-tcp'" -ErrorAction Stop | 
+      Invoke-CimMethod -MethodName SetUserAuthenticationRequired -Arguments @{UserAuthenticationRequired=[int]$NLARequired}
+      
+      Write-Debug "Completed Invoke-CimMethod on win32_TSGeneralSetting"
+
+      Write-Verbose "Set operation complete"
     
 }
 
@@ -54,41 +119,42 @@ function Test-TargetResource
 	(
 		[parameter(Mandatory = $true)]
 		[System.Boolean]
-		$Enabled
+		$Enabled,
+
+		[System.Boolean]
+        $NLARequired = $true,
+
+		[System.Boolean]
+        $EnableDefaultFirewallRule = $true
 	)
 
-	#Write-Verbose "Use this cmdlet to deliver information about command processing."
-	Write-Debug "Beginning test for RDPEnabled."
-    [Boolean]$Set = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TerminalServiceSetting).AllowTSConnections
-    switch ($Enabled)
-      {
-        $true {
-            switch ($Set)
-              {
-                $true {
-                    Write-Verbose "RDP should be set to enabled and it is currently enabled"
-                    return $true
-                  }
-                $false {
-                    Write-Verbose "RDP should be set to enabled and it is currently disabled"
-                    return $false
-                  }
-              }
-          }
-        $false {
-            switch ($Set)
-              {
-                $true {
-                    Write-Verbose "RDP should be set to disabled and it is currently enabled"
-                    return $false
-                  }
-                $false {
-                    Write-Verbose "RDP should be set to disabled and it is currently disabled"
-                    return $true
-                  }
-              }
-          }
-      }
+	Write-Verbose "Beginning Test operation"
+    [Boolean]$CurrentRDPEnabled  = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TerminalServiceSetting -ErrorAction Stop).AllowTSConnections
+    [Boolean]$CurrentNLARequired = (Get-CimInstance -Namespace root/cimv2/TerminalServices -ClassName Win32_TSGeneralSetting -Filter "TerminalName='RDP-tcp'" -ErrorAction Stop).UserAuthenticationRequired
+    $fwRules                     = Get-NetFirewallRule -DisplayName "Remote Desktop - User Mode (TCP-In)","Remote Desktop - User Mode (UDP-In)" -ErrorAction Stop
+        
+    if ($CurrentRDPEnabled -ne $Enabled) {
+        Write-Verbose ("Configuration mismatch for Enabled. Current value: {0}. Expected value: {1}" -f $CurrentRDPEnabled, $Enabled)
+        return $false
+    }
+
+    if ($CurrentNLARequired -ne $NLARequired) {
+        Write-Verbose ("Configuration mismatch for NLARequired. Current value: {0}. Expected value: {1}" -f $CurrentNLARequired, $NLARequired)
+        return $false
+    }
+
+    if ($CurrentRDPEnabled -and $EnableDefaultFirewallRule) { # We don't care about the result if RDP is not enabled
+        foreach ($rule in $fwRules) {
+            if (($rule.Enabled -eq "True") -ne $true) {
+                Write-Verbose ("Configuration mismatch for EnableDefaultFirewallRule. {0} is {1}. Expected {2}" -f $rule.DisplayName, $rule.Enabled, $EnableDefaultFirewallRule)
+                return $false
+            }
+        }
+    }
+
+    Write-Verbose "Test operation complete without configuration mismatch"
+
+    return $true
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/Resources/cRDPEnabled/DSCResources/PSHOrg_cRDPEnabled/PSHOrg_cRDPEnabled.schema.mof
+++ b/Resources/cRDPEnabled/DSCResources/PSHOrg_cRDPEnabled/PSHOrg_cRDPEnabled.schema.mof
@@ -2,6 +2,8 @@
 [ClassVersion("1.0.0.0"), FriendlyName("cRDPEnabled")]
 class PSHOrg_cRDPEnabled : OMI_BaseResource
 {
-	[Key, Description("Set to indicate is RDP should be enabled or not")] Boolean Enabled;
+	[Key, Description("Set to indicate if RDP for remote administration should be enabled or not")] Boolean Enabled;
+	[Write, Description("Require Network Level Authentication. Default value is true")] Boolean NLARequired;
+	[Write, Description("Enables the default Remote Desktop firewall rules in Windows Firewall. If set to false, the firewall rules will be left as is, no changes will be made. Default value is true")] Boolean EnableDefaultFirewallRule;
 };
 

--- a/Resources/cRDPEnabled/cRDPEnabled.psd1
+++ b/Resources/cRDPEnabled/cRDPEnabled.psd1
@@ -12,13 +12,13 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '1.0'
+ModuleVersion = '1.1.2'
 
 # ID used to uniquely identify this module
 GUID = 'c099d5e8-d953-44b7-8f84-ccde92926be7'
 
 # Author of this module
-Author = 'jmorg_000'
+Author = 'jmorg_000. Modified by Dennis Rye (llstrk)'
 
 # Company or vendor of this module
 CompanyName = 'Unknown'


### PR DESCRIPTION
Added NLARequired, which sets Network Level Authentication for RDP.
Added EnableDefaultFirewallRule, to enable the default remote desktop
rules in Windows Firewall. If set to false, it will ignore the firewall
settings, to allow for another source to control firewall rules.
Tweaked some code.
