### PR TITLE
Allow for the shortened notation of [PSCredential]

### DIFF
--- a/Tooling/DscDevelopment/New-MofFile.ps1
+++ b/Tooling/DscDevelopment/New-MofFile.ps1
@@ -108,7 +108,7 @@ class $ResourceName : OMI_BaseResource
                 {$_ -like 'string'} { $PropertyString += '] string ' }
                 {$_ -like 'switch'} { $PropertyString += '] boolean '}
                 {$_ -like 'bool'} { $PropertyString += '] boolean '}
-                {$_ -like 'System.Management.Automation.PSCredential'} { $PropertyString += ',EmbeddedInstance("MSFT_Credential")] string '}
+                {$_ -imatch '(?:System\.Management\.Automation\.)?PSCredential'} { $PropertyString += ',EmbeddedInstance("MSFT_Credential")] string '}
                 {$_ -like 'string`[`]'} { $PropertyString += '] string '; $IsArray = $true}
                 {$_ -like 'long'} { $PropertyString += '] sint64 '}
                 {$_ -like 'long`[`]'} { $PropertyString += '] sint64 '; $IsArray = $true}


### PR DESCRIPTION
The function was testing for `[System.Management.Automation.PSCredential]` but didn't know what to do to handle `[PSCredential]`. I just changed the `-like` to an `-imatch` to make it work either way.
