### PR TITLE
Adding Tests for cDscDiagnostics Module

### DIFF
--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -67,6 +67,127 @@ InModuleScope cDscDiagnostics {
             $ErrorAction = $ePreference;
         }
     }
+
+    Describe 'Trace-DscOperationInternal' {
+        Context 'SequenceID is passed' {
+            Mock -ModuleName cDscDiagnostics Log { }
+            $result = Trace-DscOperationInternal -SequenceID 0;
+            
+            It 'should return null if SequenceID is less then 1' {
+                $result | Should Be $null;
+            }
+
+            $date = Get-Date;
+            $message = "Some Message";
+            # Choosing Application because we need /something/ here and we can't assume that the machine has run a DSC command.
+            $event = Get-WinEvent -LogName Application -MaxEvents 1
+
+            $traceOutput = New-Object PSObject -Property @{
+                Type = "Operational";
+                TimeCreated = $date;
+                Message = $message;
+                ComputerName = $env:ComputerName;
+                SequenceID = 2;
+                Event = $event;
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-SingleDscOperation { return @{
+                    AllEvents = $traceOutput;
+                    ErrorEvents = "SomeEvent";
+                    JobId = "54137c5a-f607-48a5-9311-d6e102c15f83";
+                }
+            }
+
+            Mock -ModuleName cDscDiagnostics Test-DscEventLogStatus { }
+            Mock -ModuleName cDscDiagnostics Get-DscErrorMessage { return "Error Text" }
+
+            $result = Trace-DscOperationInternal -SequenceID 2;
+
+            It 'should do call Test-DscEventLogStatus' {
+                Assert-MockCalled Test-DscEventLogStatus -ModuleName cDscDiagnostics -Times 2
+            }
+
+            It 'should call Get-SingleDscOperation' {
+                Assert-MockCalled Get-SingleDscOperation -ModuleName cDscDiagnostics -Times 1
+            }
+
+            It 'should call Get-DscErrorMessage' {
+                Assert-MockCalled Get-DscErrorMessage -ModuleName cDscDiagnostics -Times 1
+            }
+
+            It 'should return the correct event type' {
+                $result.EventType | Should Be "Operational";
+            }
+
+            It 'should return the correct time' {
+                $result.TimeCreated | Should Be $date;
+            }
+
+            It 'should return the correct message' {
+                $result.Message | Should Be $message;
+            }
+
+            It 'should return the correct machine' {
+                $result.ComputerName | Should Be $env:ComputerName;
+            }
+
+            It 'should return the correct SequenceID' {
+                $result.SequenceID | Should Be 2;
+            }
+
+            It 'should return the correct Event' {
+                $result.Event | Should Be $event;
+            }
+        }
+
+        Context 'JobId Passed' {
+            $date = Get-Date;
+            $message = "Some Message";
+            # Choosing Application because we need /something/ here and we can't assume that the machine has run a DSC command.
+            $event = Get-WinEvent -LogName Application -MaxEvents 1
+
+            $traceOutput = New-Object PSObject -Property @{
+                Type = "Operational";
+                TimeCreated = $date;
+                Message = $message;
+                ComputerName = $env:ComputerName;
+                SequenceID = 1;
+                Event = $event;
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-SingleDscOperation { return @{
+                    AllEvents = $traceOutput;
+                    ErrorEvents = "SomeEvent";
+                    JobId = "54137c5a-f607-48a5-9311-d6e102c15f83";
+                }
+            }
+
+            Mock -ModuleName cDscDiagnostics Test-DscEventLogStatus { }
+            Mock -ModuleName cDscDiagnostics Get-DscErrorMessage { return "Error Text" }
+
+            $result = Trace-DscOperationInternal -SequenceID 1 -JobId "54137c5a-f607-48a5-9311-d6e102c15f83";
+
+            It 'should return the Job Id' {
+                $result.JobId | Should Be "54137c5a-f607-48a5-9311-d6e102c15f83"
+            }
+        }
+
+        Context 'Get-SingleDscOperation returns null' {
+            Mock -ModuleName cDscDiagnostics Test-DscEventLogStatus { }
+            Mock -ModuleName cDscDiagnostics Get-SingleDscOperation { }
+
+            $result = Trace-DscOperationInternal -SequenceID 1 -JobId "54137c5a-f607-48a5-9311-d6e102c15f83";
+
+            It 'should return null' {
+                $result | Should Be $null;
+            }
+        }
+
+        # This way we don't cache anything while testing.
+        AfterEach {
+            Clear-DscDiagnosticsCache
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -237,6 +237,37 @@ InModuleScope cDscDiagnostics {
             $result | Should Not Be $null;
         }
     }
+
+    Describe 'Get-AllGroupedDscEvents' {
+        Context 'Get-AllDscEvents is empty' {
+            Mock -ModuleName cDscDiagnostics Get-DscLatestJobId {}
+            Mock -ModuleName cDscDiagnostics Get-AllDscEvents {}
+            Mock -ModuleName cDscDiagnostics Log {}
+
+            $result = Get-AllGroupedDscEvents;
+
+            It 'should return nothing' {
+                $result  | Should BeNullorEmpty
+            }
+        }
+
+        Context 'Get-AllDscEvents is not empty' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {
+                Microsoft.PowerShell.Diagnostics\Get-WinEvent -LogName Application -MaxEvents 1
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-DscLatestJobId {}
+            $result = Get-AllGroupedDscEvents;
+
+            It 'should return GroupInfo' {
+                $result | Should Be Microsoft.PowerShell.Commands.GroupInfo
+            }
+        }
+
+        AfterEach {
+            Clear-DscDiagnosticsCache
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -532,7 +532,7 @@ InModuleScope cDscDiagnostics {
             $result | should be "Output Error Message "
         }
     }
-    
+
     Describe 'Get-SingleRelevantErrorMessage' {
         Context 'Property Index is -1' {
             $value = @{Value = "Property"}
@@ -562,6 +562,25 @@ InModuleScope cDscDiagnostics {
             It 'should reutrn the correct string' {
                 $result | should be "Mocked Message"
             }
+        }
+    }
+
+    Describe 'Get-DscOperationInternal' {
+        Mock -ModuleName cDscDiagnostics Get-AllGroupedDscEvents { return "GroupedEvents" }
+        Mock -ModuleName cDscDiagnostics Split-SingleDscGroupedRecord  { return "singleOutputRecord" }
+
+        $result = Get-DscOperationInternal -Newest 1;
+
+        It 'should call Get-AllGroupedDscEvents' {
+            Assert-MockCalled Get-AllGroupedDscEvents -ModuleName cDscDiagnostics
+        }
+
+        It 'should loop over the events the correct amount of times' {
+            Assert-MockCalled Split-SingleDscGroupedRecord -ModuleName cDscDiagnostics -Times 1
+        }
+
+        It 'should return the singleOutputRecord' {
+            $result | Should Be "singleOutputRecord"
         }
     }
 }

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -72,7 +72,7 @@ InModuleScope cDscDiagnostics {
         Context 'SequenceID is passed' {
             Mock -ModuleName cDscDiagnostics Log { }
             $result = Trace-DscOperationInternal -SequenceID 0;
-            
+
             It 'should return null if SequenceID is less then 1' {
                 $result | Should Be $null;
             }
@@ -184,6 +184,38 @@ InModuleScope cDscDiagnostics {
         }
 
         # This way we don't cache anything while testing.
+        AfterEach {
+            Clear-DscDiagnosticsCache
+        }
+    }
+
+    Describe 'Get-DscLatestJobId' {
+        Context 'It has a Job to Return' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {
+                $value = @{"Value" = "{3BBB79B7-BD46-424C-9718-983C8C76D37E}"}
+                $returnObject = @(@{Properties = @($value)}, [Environment]::NewLine)
+                return @(@{Properties = @($value)}, [Environment]::NewLine)
+            }
+
+            $result = Get-DscLatestJobId;
+
+            It 'should return the GUID' {
+                $result | Should Be "{3BBB79B7-BD46-424C-9718-983C8C76D37E}"
+            }
+        }
+
+        Context 'When it does not have a Job' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {
+                return $null
+            }
+
+            $result = Get-DscLatestJobId;
+
+            It 'should return "NOJOBID"' {
+                $result | Should Be "NOJOBID"
+            }
+        }
+
         AfterEach {
             Clear-DscDiagnosticsCache
         }

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module .\cDscDiagnostics.psm1
+Import-Module $PSScriptRoot\cDscDiagnostics.psm1
 
 Describe "Trace-cDscOperation" {
     Context "does it call its internal functions" {
@@ -56,15 +56,15 @@ InModuleScope cDscDiagnostics {
 
         BeforeEach {
             $vPreference = $VerbosePreference;
-            $ePreference = $ErrorAction;
+            $ePreference = $ErrorActionPreference;
 
             $VerbosePreference = "Continue";
-            $ErrorAction = "Continue";
+            $ErrorActionPreference = "Continue";
         }
 
         AfterEach {
             $VerbosePreference = $vPreference;
-            $ErrorAction = $ePreference;
+            $ErrorActionPreference = $ePreference;
         }
     }
 

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -583,6 +583,62 @@ InModuleScope cDscDiagnostics {
             $result | Should Be "singleOutputRecord"
         }
     }
+
+    Describe 'Test-DscEventLogStatus' {
+        Context 'Log is Enabled' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {return @{IsEnabled = $true}}
+            $result = Test-DscEventLogStatus
+
+            It 'should return true' {
+                $result | Should Be $true
+            }
+        }
+
+        Context 'Log is Disabled and not enabled' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {return @{IsEnabled = $false}}
+            Mock -ModuleName cDscDiagnostics Log {}
+            Mock -ModuleName cDscDiagnostics Read-Host {return "n"};
+
+            $result = Test-DscEventLogStatus
+
+            It 'should return false' {
+                $result | Should Be $false
+            }
+
+            It 'should call Log' {
+                Assert-MockCalled Log -ModuleName cDscDiagnostics
+            }
+
+            It 'should call Read-Host' {
+                Assert-MockCalled Read-Host -ModuleName cDscDiagnostics
+            }
+        }
+
+        Context 'Log is Disabled and is enabled' {
+            Mock -ModuleName cDscDiagnostics Get-WinEvent {return @{IsEnabled = $false}}
+            Mock -ModuleName cDscDiagnostics Enable-DscEventLog {}
+            Mock -ModuleName cDscDiagnostics Read-Host {return "y"};
+            Mock -ModuleName cDscDiagnostics Write-Host {};
+
+            $result = Test-DscEventLogStatus
+
+            It 'should return false' {
+                $result | Should Be $false
+            }
+
+            It 'should call Write-Host' {
+                Assert-MockCalled Write-Host -ModuleName cDscDiagnostics
+            }
+
+            It 'should call Read-Host' {
+                Assert-MockCalled Read-Host -ModuleName cDscDiagnostics
+            }
+
+            It 'should call Enable-DscEventLog' {
+                Assert-MockCalled Enable-DscEventLog -ModuleName cDscDiagnostics
+            }
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -21,3 +21,21 @@ Describe "Trace-cDscOperation" {
         }
     }
 }
+
+Describe "Add-ClassTypes" {
+    Context "when its called" {
+        Mock -ModuleName cDscDiagnostics Update-FormatData {}
+        Mock -ModuleName cDscDiagnostics Trace-DscOperationInternal {}
+        Mock -ModuleName cDscDiagnostics Log {}
+
+        $result = Trace-cDscOperation -ComputerName $env:ComputerName;
+
+        It "should have loaded it's event types" {
+            { [Microsoft.PowerShell.cDscDiagnostics.EventType]::ANALYTIC } | Should Not Throw
+        }
+
+        It "should have loaded it's group events" {
+            { [Microsoft.PowerShell.cDscDiagnostics.GroupedEvents] } | Should Not Throw
+        }
+    }
+}

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -220,6 +220,23 @@ InModuleScope cDscDiagnostics {
             Clear-DscDiagnosticsCache
         }
     }
+
+    Describe 'Get-AllDscEvents' {
+        Mock -ModuleName cDscDiagnostics Get-WinEvent {
+            Microsoft.PowerShell.Diagnostics\Get-WinEvent -LogName Application -MaxEvents 1
+        }
+
+        $result = Get-AllDscEvents;
+
+        It 'should do call Get-WinEvent for each log passed' {
+            Assert-MockCalled Get-WinEvent -ModuleName cDscDiagnostics -Times 3
+            $result.Count | Should Be 3
+        }
+
+        It 'should return something' {
+            $result | Should Not Be $null;
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -39,3 +39,25 @@ Describe "Add-ClassTypes" {
         }
     }
 }
+
+Describe "Get-cDscOperation" {
+    Context "does it call its internal functions" {
+        Mock -ModuleName cDscDiagnostics Add-ClassTypes {}
+        Mock -ModuleName cDscDiagnostics Get-DscOperationInternal {}
+        Mock -ModuleName cDscDiagnostics Log {}
+
+        $result = Get-cDscOperation -ComputerName $env:ComputerName;
+
+        It "should call Add-ClassType" {
+            Assert-MockCalled Add-ClassTypes -ModuleName cDscDiagnostics -Times 1
+        }
+
+        It "should call Get-DscOperationInternal" {
+            Assert-MockCalled Get-DscOperationInternal -ModuleName cDscDiagnostics -Times 1
+        }
+
+        It "should call Log" {
+            Assert-MockCalled Log -ModuleName cDscDiagnostics -Times 1
+        }
+    }
+}

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -532,6 +532,38 @@ InModuleScope cDscDiagnostics {
             $result | should be "Output Error Message "
         }
     }
+    
+    Describe 'Get-SingleRelevantErrorMessage' {
+        Context 'Property Index is -1' {
+            $value = @{Value = "Property"}
+            $hash = @([Environment]::NewLine; $value)
+            $errorEvent = @{Id = 4131; Properties = $hash}
+
+            $result = Get-SingleRelevantErrorMessage -ErrorEvent $errorEvent;
+
+            It 'should reutrn the correct string' {
+                $result | should be "Property"
+            }
+        }
+
+        Context 'Property Index is not -1' {
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $value = @{Value = "Property"}
+            $hash = @([Environment]::NewLine; $value)
+            $errorEvent = @{Id = 4183; Properties = $hash}
+
+            $result = Get-SingleRelevantErrorMessage -ErrorEvent $errorEvent;
+
+            It 'should call Get-MessageFromEvent' {
+                Assert-MockCalled Get-MessageFromEvent -ModuleName cDscDiagnostics
+            }
+
+            It 'should reutrn the correct string' {
+                $result | should be "Mocked Message"
+            }
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -312,6 +312,185 @@ InModuleScope cDscDiagnostics {
             }
         }
     }
+
+    Describe 'Split-SingleDscGroupedRecord' {
+        Context 'Passed an bad DSC record' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 2;
+                    ContainerLog = "Microsoft-Windows-Dsc/Operational";
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+                Count = 1
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            It 'should have SequenceID match the index' {
+                $result.SequenceID | Should Be 0
+            }
+
+            It 'should have ComputerName match this computer' {
+                $result.ComputerName | Should Be $env:ComputerName
+            }
+
+            It 'should have a failure as the result' {
+                $result.Result | Should Be "Failure"
+            }
+
+            It 'should have error as the type' {
+                $result.AllEvents[0].Type | Should Be "ERROR"
+            }
+
+            It 'should have the mocked message' {
+                $result.AllEvents[0].Message | Should Be "Mocked Message"
+            }
+
+            It 'should have the right JobId' {
+                $result.JobId | Should Be "54137C5A-F607-48A5-9311-D6E102C15F83"
+            }
+
+            It 'should have the right count' {
+                $result.NumberOfEvents | Should Be 1
+            }
+        }
+
+        Context 'Passing a Warning' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 1;
+                    ContainerLog = "Microsoft-Windows-Dsc/Operational";
+                    LevelDisplayName = "Warning";
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            it 'should find a warning event' {
+                $result.WarningEvents | Should Not Be $null
+            }
+        }
+
+        Context 'Passing an Operational Log' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 1;
+                    ContainerLog = "Microsoft-Windows-Dsc/operational";
+                    LevelDisplayName = "Operational";
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            It 'should find the right type' {
+                $result.AllEvents[0].Type | Should Be "OPERATIONAL"
+            }
+
+            It 'should find some operational events' {
+                $result.OperationalEvents | Should Not Be $null
+            }
+
+            It 'should find some non-verbose events' {
+                $result.NonVerboseEvents | Should Not Be $null
+            }
+        }
+
+        Context 'Passing a Debug Log' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 1;
+                    ContainerLog = "Microsoft-Windows-Dsc/debug";
+                    LevelDisplayName = "Debug";
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            It 'should find the right type' {
+                $result.AllEvents[0].Type | Should Be "DEBUG"
+            }
+
+            It 'should find some debug events' {
+                $result.DebugEvents | Should Not Be $null
+            }
+        }
+
+        Context 'Passing a Verbose Log' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 1;
+                    ContainerLog = "Microsoft-Windows-Dsc/analytic";
+                    LevelDisplayName = "analytic";
+                    Id = 4100;
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            It 'should find the right type' {
+                $result.AllEvents[0].Type | Should Be "Verbose"
+            }
+
+            It 'should find some debug events' {
+                $result.VerboseEvents | Should Not Be $null
+            }
+        }
+
+        Context 'Passing an Analytic Log' {
+            $TimeCreated = Get-Date;
+            $singleRecordInGroupedEvents = New-Object PSObject -Property @{
+                Group = New-Object PSObject -Property @{
+                    Guid = "3bbb79b7-bd46-424c-9718-983c8c76d37e"
+                    TimeCreated = $TimeCreated;
+                    Level = 1;
+                    ContainerLog = "Microsoft-Windows-Dsc/analytic";
+                    LevelDisplayName = "analytic";
+                }
+                Name = "{54137C5A-F607-48A5-9311-D6E102C15F83}"
+            }
+
+            Mock -ModuleName cDscDiagnostics Get-MessageFromEvent {return "Mocked Message"}
+
+            $result = Split-SingleDscGroupedRecord -singleRecordInGroupedEvents $singleRecordInGroupedEvents -Index 0;
+
+            It 'should find the right type' {
+                $result.AllEvents[0].Type | Should Be "Analytic"
+            }
+
+            It 'should find some analytic events' {
+                $result.NonVerboseEvents | Should Not Be $null
+            }
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -40,6 +40,35 @@ Describe "Add-ClassTypes" {
     }
 }
 
+InModuleScope cDscDiagnostics {
+    Describe 'Log' {
+        It 'Should write verbosely' {
+            $text = "Verbose Text"
+            $verboseLog = Log $text -Verbose 4>&1
+            $verboseLog | Should Be $text
+        }
+
+        It 'should write errors' {
+            $text = "Error Text"
+            $errorLog = Log $text -Error 2>&1
+            $errorLog | Should Be $text
+        }
+
+        BeforeEach {
+            $vPreference = $VerbosePreference;
+            $ePreference = $ErrorAction;
+
+            $VerbosePreference = "Continue";
+            $ErrorAction = "Continue";
+        }
+
+        AfterEach {
+            $VerbosePreference = $vPreference;
+            $ErrorAction = $ePreference;
+        }
+    }
+}
+
 Describe "Get-cDscOperation" {
     Context "does it call its internal functions" {
         Mock -ModuleName cDscDiagnostics Add-ClassTypes {}

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -521,6 +521,17 @@ InModuleScope cDscDiagnostics {
             }
         }
     }
+
+    Describe 'Get-DscErrorMessage' {
+        Mock -ModuleName cDscDiagnostics Get-SingleRelevantErrorMessage {return "Output Error Message"}
+        $errorRecords = @{Id = "4131";}
+
+        $result = Get-DscErrorMessage -ErrorRecords $errorRecords
+
+        It 'should be the message' {
+            $result | should be "Output Error Message "
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -491,6 +491,36 @@ InModuleScope cDscDiagnostics {
             }
         }
     }
+
+    Describe 'Get-MessageFromEvent' {
+        Context 'For a non-verbose event' {
+            $eventRecord = New-Object PSObject -Property @{
+                Message = [Environment]::NewLine + "Some Message";
+            }
+
+            $result = Get-MessageFromEvent -EventRecord $eventRecord
+
+            It 'should return the value' {
+                $result | Should Be "Some Message"
+            }
+        }
+
+        Context 'For a verbose event' {
+            $verboseMessage = New-Object PSObject -Property @{Value = "Verbose Message"}
+            $value = @([Environment]::NewLine, [Environment]::NewLine, $verboseMessage)
+            $eventRecord = New-Object PSObject -Property @{
+                Message = [Environment]::NewLine + "Some Message";
+                Id = 4117
+                Properties = $value;
+            }
+
+            $result = Get-MessageFromEvent -EventRecord $eventRecord -verboseType
+
+            It 'should return the value' {
+                $result | Should Be "Verbose Message"
+            }
+        }
+    }
 }
 
 Describe "Get-cDscOperation" {

--- a/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
+++ b/Tooling/cDscDiagnostics/cDscDiagnostics.psm1.Tests.ps1
@@ -1,0 +1,23 @@
+Import-Module .\cDscDiagnostics.psm1
+
+Describe "Trace-cDscOperation" {
+    Context "does it call its internal functions" {
+        Mock -ModuleName cDscDiagnostics Add-ClassTypes {}
+        Mock -ModuleName cDscDiagnostics Trace-DscOperationInternal {}
+        Mock -ModuleName cDscDiagnostics Log {}
+
+        $result = Trace-cDscOperation -ComputerName $env:ComputerName;
+
+        It "should call Add-ClassType" {
+            Assert-MockCalled Add-ClassTypes -ModuleName cDscDiagnostics -Times 1
+        }
+
+        It "should call Trace-DscOperationInternal" {
+            Assert-MockCalled Trace-DscOperationInternal -ModuleName cDscDiagnostics -Times 1
+        }
+
+        It "should call Log" {
+            Assert-MockCalled Log -ModuleName cDscDiagnostics -Times 1
+        }
+    }
+}


### PR DESCRIPTION
Given I wanted to change some of the functions to expose them to the public, correct some of the logic that exists in the module, and learn Pester I figured this was a good module to write tests for. This should cover all functions except two, Get-WinEvent and Enable-DscEventLog.  Enable-DscEventLog wasn't tested because I couldn't figure out a good way (without modifying the function to mock wevtutil.  I'm sure someone smarter then me will know a good way to test this.  Get-WinEvent wasn't tested because I couldn't figure out how to mock the wrapper instead of the specific module.

This is also written to test the master branch as written.  So it does not include any of my modifications to Test-DscEventLogStatus or Enable-DscEventLog, these tests will need to be rewritten if those changes are going to be taken.

Completely open to feedback as this is the first real dive into Pester.